### PR TITLE
修复Web控制端中重启GAEProxy失败的问题

### DIFF
--- a/gae_proxy/start.py
+++ b/gae_proxy/start.py
@@ -11,10 +11,15 @@ if os.path.islink(__file__):
 current_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(current_path)
 import local.proxy as client
-
+import local.connect_control as connect_control
+import local.xlog as xlog
 
 def main():
     try:
+        xlog.debug("# TODO keep_running: %s", connect_control.keep_running)
+        # gae_proxy/local/proxy.py will check 'keep_running' looply
+        # if gae_proxy wants to be up, 'keep_running' should NOT be False
+        connect_control.keep_running = True
         client.main()
     except KeyboardInterrupt:
         sys.exit()


### PR DESCRIPTION
**tryitout branch**
see #1082
临时修复，Web控制端重启GAEProxy失败的问题
- set keep_running = True to make gae_proxy restart successfully

先合到自己的tryitout分支玩玩 :smiley: 
